### PR TITLE
Migrate to fit in agent identity owner and subregion concept

### DIFF
--- a/ngrinder-networkoverflow/pom.xml
+++ b/ngrinder-networkoverflow/pom.xml
@@ -16,9 +16,11 @@
     </licenses>
     
     <properties>
+		<maven.compiler.source>1.7</maven.compiler.source>
+		<maven.compiler.target>1.7</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.7</java.version>
-		<ngrinder.core.version>3.5.0</ngrinder.core.version>
+		<ngrinder.core.version>3.5.5</ngrinder.core.version>
         <plugin.id>ngrinder-networkoverflow</plugin.id>
         <plugin.class>org.ngrinder.network.PhysicalNetworkOverFlow</plugin.class>
         <plugin.version>3.3.2</plugin.version>
@@ -69,11 +71,7 @@
 		<repository>
 			<id>maven-repo</id>
 			<name>Official Repository</name>
-			<url>http://repo1.maven.org/maven2</url>
-		</repository>
-		<repository>
-			<id>nhnopensource.maven.repo</id>
-			<url>https://github.com/nhnopensource/nhnopensource.maven.repo/raw/master/releases</url>
+			<url>https://repo1.maven.org/maven2</url>
 		</repository>
 	</repositories>
 

--- a/ngrinder-networkoverflow/pom.xml
+++ b/ngrinder-networkoverflow/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.ngrinder</groupId>
 	<artifactId>ngrinder-networkoverflow</artifactId>
-	<version>3.3.2</version>
+	<version>3.3.3</version>
 	<name>ngrinder-networkoverflow</name>
 	<description>ngrinder-networkoverflow Plugin Framework for Java</description>
 	
@@ -23,7 +23,7 @@
 		<ngrinder.core.version>3.5.5</ngrinder.core.version>
         <plugin.id>ngrinder-networkoverflow</plugin.id>
         <plugin.class>org.ngrinder.network.PhysicalNetworkOverFlow</plugin.class>
-        <plugin.version>3.3.2</plugin.version>
+        <plugin.version>3.3.3</plugin.version>
         <plugin.provider>NAVER</plugin.provider>
         <plugin.dependencies />
     </properties>

--- a/ngrinder-networkoverflow/src/main/java/org/ngrinder/network/NetworkOverFlow.java
+++ b/ngrinder-networkoverflow/src/main/java/org/ngrinder/network/NetworkOverFlow.java
@@ -59,7 +59,7 @@ public class NetworkOverFlow extends Plugin {
 		public void startSampling(ISingleConsole singleConsole, PerfTest perfTest,
 			IPerfTestService perfTestService) {
 			LOGGER.info("Test Id: {}", perfTest.getId());
-			LOGGER.info("Test Name: {}, Test Time: {}", perfTest.getTestName(), perfTest.getCreatedDate());
+			LOGGER.info("Test Name: {}, Test Time: {}", perfTest.getTestName(), perfTest.getCreatedAt());
 
 			int totalAgentSize = singleConsole.getAllAttachedAgents().size();
 			int consolePort = singleConsole.getConsolePort();
@@ -77,7 +77,7 @@ public class NetworkOverFlow extends Plugin {
 
 				if (each.getPort() == consolePort) {
 					agentCount++;
-					if (StringUtils.contains(each.getRegion(), "owned")) {
+					if (StringUtils.isNotEmpty(each.getOwner())) {
 						LOGGER.info("userSpecific agent name: {}, userSpecific agent region: {}", each.getName(), each.getRegion());
 						userSpecificAgentCount++;
 					}

--- a/ngrinder-networkoverflow/src/main/java/org/ngrinder/network/PhysicalNetworkOverFlow.java
+++ b/ngrinder-networkoverflow/src/main/java/org/ngrinder/network/PhysicalNetworkOverFlow.java
@@ -50,11 +50,10 @@ public class PhysicalNetworkOverFlow extends Plugin {
 			if (workingAgents.isEmpty()) {
 				return;
 			}
-			String region = "";
+
 			for (AgentStatus each : workingAgents) {
-				final String eachAgentRegion = ((AgentControllerIdentityImplementation) each.getAgentIdentity()).getRegion();
-				if (!StringUtils.contains(eachAgentRegion, "owned_")) {
-					region = eachAgentRegion;
+				final String owner = ((AgentControllerIdentityImplementation) each.getAgentIdentity()).getOwner();
+				if (StringUtils.isEmpty(owner)) {
 					totalReceived += each.getSystemDataModel().getReceivedPerSec();
 					totalSent += each.getSystemDataModel().getSentPerSec();
 				}
@@ -63,15 +62,14 @@ public class PhysicalNetworkOverFlow extends Plugin {
 			int limit = config.getControllerProperties().getPropertyInt(
 				PROP_NETWORK_OVERFLOW_LIMIT, PROP_NETWORK_OVERFLOW_LIMIT_DEFAULT) * 1024 * 1024;
 			if (totalReceived > limit || totalSent > limit) {
-				LOGGER.debug("LIMIT : {}, RX : {}, TX : {}", new Object[]{limit, totalReceived,
-					totalSent});
+				LOGGER.debug("LIMIT : {}, RX : {}, TX : {}", new Object[]{limit, totalReceived, totalSent});
 				for (PerfTest perfTest : perfTestService.getAllTesting()) {
 					if (perfTest.getStatus() != Status.ABNORMAL_TESTING) {
 						perfTestService.markStatusAndProgress(
 							perfTest,
 							Status.ABNORMAL_TESTING,
-							String.format("Too much traffic on the region %s. Stop by force.\n"
-								+ "- LIMIT/s: %s\n" + "- RX/s: %s / TX/s: %s", region,
+							String.format("Too much traffic on current region. Stop by force.\n"
+								+ "- LIMIT/s: %s\n" + "- RX/s: %s / TX/s: %s",
 								UnitUtils.byteCountToDisplaySize(limit),
 								UnitUtils.byteCountToDisplaySize(totalReceived),
 								UnitUtils.byteCountToDisplaySize(totalSent)));


### PR DESCRIPTION
- Migrate to depends on ngrinder-core 3.5.5
- Figure out dedicated agent with the `owner` field
- It's hard to figure out where the current region is in this context. So, just change logging message.